### PR TITLE
Support entity instance deletion by ref

### DIFF
--- a/src/steputils/p21.py
+++ b/src/steputils/p21.py
@@ -337,6 +337,24 @@ class StepFile:
             self._rebuild_chain_map()
         return self._linked_data_sections[ref]
 
+    def __delitem__(self, ref: str):
+        """ Deletes entity instance by instance name `ref` from all data sections.
+
+        Args:
+            ref: entity instance name as string e.g. ``'#100'``
+
+        Raises:
+              KeyError: instance `id` not found
+
+        """
+        deleted = False
+        for mapping in self._linked_data_sections.maps:
+            if ref in mapping:
+                del mapping[ref]
+                deleted = True
+        if not deleted:
+            raise KeyError(ref)
+
     def __len__(self) -> int:
         """ Returns count of all stored entity instances. """
         return len(self._linked_data_sections)

--- a/tests/p21/test_p21_api.py
+++ b/tests/p21/test_p21_api.py
@@ -48,6 +48,13 @@ def test_step_file_getter(stpfile):
     assert stpfile['#1'].ref == '#1'
 
 
+def test_step_file_delete_entity_instance_by_ref(stpfile):
+    assert stpfile['#100'].ref == '#100'
+    del stpfile['#100']
+    with pytest.raises(KeyError):
+        stpfile['#100']
+
+
 def test_len(stpfile):
     assert len(stpfile) == 2
 


### PR DESCRIPTION
The `StepFile` already has a dict-like interface for retrieving entity instances by `ref`.

I found this helpful to also be able to delete entity instances from the `StepFile`  with `del stepfile[ref]`. This is needed for the script that I am writing to automate step files cleanup.