### PR TITLE
Fix incorrect try/except syntax in p21 parser

### DIFF
--- a/src/steputils/p21.py
+++ b/src/steputils/p21.py
@@ -665,7 +665,7 @@ class Parser:
     def pop(self):
         try:
             return self.tokens.pop()
-        except IndexError():
+        except IndexError:
             raise ParseError('Unexpected end of file.')
 
     def _keyword(self):


### PR DESCRIPTION
this currently raises:

```
  File "/images/.venv/lib/python3.10/site-packages/steputils/p21.py", line 668, in pop
    except IndexError():
TypeError: catching classes that do not inherit from BaseException is not allowed
```

cc @w0rm 